### PR TITLE
Update coq.tmLanguage

### DIFF
--- a/client/syntaxes/coq.tmLanguage
+++ b/client/syntaxes/coq.tmLanguage
@@ -45,7 +45,7 @@
 
         <dict>
             <key>match</key>
-            <string>(Theorem|Lemma|Remark|Fact|Corollary|Property|Proposition|Goal)\s+(\p{L}(\p{L}|[0-9_'])*)</string>
+            <string>(Theorem|Lemma|Remark|Fact|Corollary|Property|Proposition|Goal)\s+((\p{L}|_)(\p{L}|[0-9_'])*)</string>
             <key>comment</key>
             <string>Theorem declarations</string>
             <key>captures</key>
@@ -65,7 +65,7 @@
 
         <dict>
             <key>match</key>
-            <string>(Parameters?|Axioms?|Conjectures?|Variables?|Hypothesis|Hypotheses)\s+(\p{L}(\p{L}|[0-9_'])*)</string>
+            <string>(Parameters?|Axioms?|Conjectures?|Variables?|Hypothesis|Hypotheses)\s+((\p{L}|_)(\p{L}|[0-9_'])*)</string>
             <key>comment</key>
             <string>Assumptions</string>
             <key>captures</key>
@@ -86,7 +86,7 @@
 
         <dict>
             <key>match</key>
-            <string>(Program Definition|Program Fixpoint|Program CoFixpoint|Program Function|Function|CoFixpoint|Fixpoint|Definition|Example|Let)\s+(\p{L}(\p{L}|[0-9_'])*)</string>
+            <string>(Program Definition|Program Fixpoint|Program CoFixpoint|Program Function|Function|CoFixpoint|Fixpoint|Definition|Example|Let)\s+((\p{L}|_)(\p{L}|[0-9_'])*)</string>
             <key>comment</key>
             <string>Definitions</string>
             <key>captures</key>
@@ -106,7 +106,7 @@
 
         <dict>
             <key>match</key>
-            <string>(CoInductive|Inductive)\s+(\p{L}(\p{L}|[0-9_'])*)</string>
+            <string>(CoInductive|Inductive)\s+((\p{L}|_)(\p{L}|[0-9_'])*)</string>
             <key>comment</key>
             <string>Inductive type declarations</string>
             <key>captures</key>
@@ -126,7 +126,7 @@
 
         <dict>
             <key>match</key>
-            <string>(Ltac)\s+(\p{L}(\p{L}|[0-9_'])*)</string>
+            <string>(Ltac)\s+((\p{L}|_)(\p{L}|[0-9_'])*)</string>
             <key>comment</key>
             <string>Ltac declarations</string>
             <key>captures</key>


### PR DESCRIPTION
identifiers can start with underscore